### PR TITLE
Altera sdk buscando por lista de tracking codes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.12-BETA
+version=0.0.13-BETA

--- a/src/main/java/br/com/correios/api/rastreio/model/DetalhesRastreio.java
+++ b/src/main/java/br/com/correios/api/rastreio/model/DetalhesRastreio.java
@@ -1,0 +1,59 @@
+package br.com.correios.api.rastreio.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Alexandre Gama
+ * 
+ * @description Classe que contem todas as informacoes de um Objeto Rastreado, inclusive os eventos associados ao Objeto em questao
+ * 
+ * @since 0.0.1-BETA
+ */
+public class DetalhesRastreio {
+
+	/**
+	 * Versão do SRO XML
+	 */
+	private String versao;
+	
+	/**
+	 * Quantidade de objetos consultados
+	 */
+	private Integer quantidade;
+	
+	/**
+	 * Lista de objetos rastreados
+	 */
+	private List<ObjetoRastreio> objetosRastreio = new ArrayList<ObjetoRastreio>();
+	
+	public String getVersao() {
+		return versao;
+	}
+
+	public void setVersao(String versao) {
+		this.versao = versao;
+	}
+
+	public Integer getQuantidade() {
+		return quantidade;
+	}
+
+	public void setQuantidade(Integer quantidade) {
+		this.quantidade = quantidade;
+	}
+	
+	public void adicionaObjetoRastreio(ObjetoRastreio objetoRastreio) {
+		this.objetosRastreio.add(objetoRastreio);
+	}
+	
+	public List<ObjetoRastreio> getObjetosRastreio() {
+		return objetosRastreio;
+	}
+
+	@Override
+	public String toString() {
+		return "DetalhesRastreio [versao=" + versao + ", quantidade=" + quantidade + ", objetosRastreio=" + objetosRastreio + "]";
+	}
+
+}

--- a/src/main/java/br/com/correios/api/rastreio/model/ObjetoRastreio.java
+++ b/src/main/java/br/com/correios/api/rastreio/model/ObjetoRastreio.java
@@ -1,4 +1,4 @@
-package br.com.correios.api.rastreio.service;
+package br.com.correios.api.rastreio.model;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -8,65 +8,32 @@ import com.google.common.base.Optional;
 
 import br.com.correios.api.rastreio.model.Evento;
 
-/**
- * @author Alexandre Gama
- * 
- * @description Classe que contem todas as informacoes de um Objeto Rastreado, inclusive os eventos associados ao Objeto em questao
- * 
- * @since 0.0.1-BETA
- */
-public class PacoteRastreadoDetalhes {
+public class ObjetoRastreio {
 
-	/**
-	 * Versão do SRO XML
-	 */
-	private String versao;
-	
-	/**
-	 * Quantidade de objetos consultados
-	 */
-	private Integer quantidade;
-	
 	/**
 	 * Número do objeto
 	 */
 	private String numero;
-	
+
 	/**
 	 * Sigla do objeto solicitado
 	 */
 	private String sigla;
-	
+
 	/**
 	 * Nome do objeto solicitado
 	 */
 	private String nome;
-	
+
 	/**
 	 * Categoria do objeto solicitado
 	 */
 	private String categoria;
-	
+
 	/**
 	 * Lista dos eventos que ocorreram com o objeto desejado
 	 */
-	private List<Evento> eventos = new ArrayList<Evento>();
-
-	public String getVersao() {
-		return versao;
-	}
-
-	public void setVersao(String versao) {
-		this.versao = versao;
-	}
-
-	public Integer getQuantidade() {
-		return quantidade;
-	}
-
-	public void setQuantidade(Integer quantidade) {
-		this.quantidade = quantidade;
-	}
+	private List<Evento> eventos = new ArrayList<>();
 
 	public List<Evento> getEventos() {
 		return Collections.unmodifiableList(eventos);
@@ -109,16 +76,16 @@ public class PacoteRastreadoDetalhes {
 	}
 
 	public int getQuantidadeDeEventosOcorridos() {
-		return eventos.size() > 0 ? eventos.size(): 0; 
+		return eventos.size() > 0 ? eventos.size(): 0;
 	}
-	
+
 	public Optional<Evento> getPrimeiroEvento() {
 		if (eventos.size() > 0) {
 			return Optional.of(eventos.get(0));
 		}
-		return Optional.absent(); 
+		return Optional.absent();
 	}
-	
+
 	public Optional<Evento> getUltimoEvento() {
 		if (eventos.size() > 0) {
 			return Optional.of(eventos.get(eventos.size() - 1));
@@ -128,8 +95,7 @@ public class PacoteRastreadoDetalhes {
 
 	@Override
 	public String toString() {
-		return "PacoteRastreadoDetalhes [versao=" + versao + ", quantidade=" + quantidade + ", numero=" + numero
-				+ ", sigla=" + sigla + ", nome=" + nome + ", categoria=" + categoria + ", eventos=" + eventos + "]";
+		return "ObjetoRastreio [numero=" + numero + ", sigla=" + sigla + ", nome=" + nome + ", categoria=" + categoria + ", eventos=" + eventos + "]";
 	}
-	
+
 }

--- a/src/main/java/br/com/correios/api/rastreio/service/CorreiosRastreioApi.java
+++ b/src/main/java/br/com/correios/api/rastreio/service/CorreiosRastreioApi.java
@@ -6,19 +6,20 @@ import static br.com.correios.api.rastreio.model.CorreiosIdioma.INGLES;
 import static br.com.correios.api.rastreio.model.CorreiosIdioma.PORTUGUES;
 import static br.com.correios.api.rastreio.model.CorreiosTipoIdentificador.LISTA_DE_OBJETOS;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import br.com.correios.api.exception.CorreiosCodigoRastreioInvalidoException;
 import br.com.correios.api.rastreio.model.CorreiosEscopoResultado;
 import br.com.correios.api.rastreio.model.CorreiosIdioma;
+import br.com.correios.api.rastreio.model.DetalhesRastreio;
+import br.com.correios.api.rastreio.model.ObjetoRastreio;
 import br.com.correios.credentials.CorreiosCredenciais;
 
 /**
  * @author Alexandre Gama
- * 
+ *
  * @description Classe que deve ser usada para as chamadas a API dos Correios
- * 
+ *
  * @since 0.0.1-BETA
  */
 public class CorreiosRastreioApi {
@@ -37,7 +38,7 @@ public class CorreiosRastreioApi {
 		this.trackingCode = trackingCode;
 		return new CorreiosRastreioComIdioma();
 	}
-	
+
 	public CorreiosRastreioComIdioma buscaPacoteTrackerPelaListaDeTrackings(List<String> trackingCodes) {
 		this.trackingCodes = trackingCodes;
 		return new CorreiosRastreioComIdioma();
@@ -70,8 +71,8 @@ public class CorreiosRastreioApi {
 			 * Metodo para retornar somente o ultimo evento de um Pacote Rastreado.
 			 * Note que neste caso passamos para o correios um parametro diferenciado indicando que sera retornado somente o ultimo evento
 			 * Note tambem que neste caso a lista de eventos sera preenchida com somente 1 evento.
-			 * Para retornar somente o ultimo evento do Pacote rastreado basta usar o metodo {@link PacoteRastreadoDetalhes#getUltimoEvento()}
-			 * 
+			 * Para retornar somente o ultimo evento do Pacote rastreado basta usar o metodo {@link ObjetoRastreio#getUltimoEvento()}
+			 *
 			 * @return CorreiosRastreioTracker
 			 */
 			public CorreiosRastreioTracker somenteUltimoEvento() {
@@ -81,44 +82,36 @@ public class CorreiosRastreioApi {
 
 			public class CorreiosRastreioTracker {
 
-				public PacoteRastreadoDetalhes getPacoteRastreado() {
+				public DetalhesRastreio getPacoteRastreado() {
 					boolean usuarioEnviouListaDeTrackingCodes = trackingCodes != null && !trackingCodes.isEmpty();
 					if (usuarioEnviouListaDeTrackingCodes) {
 						throw new CorreiosCodigoRastreioInvalidoException("Voce deve fazer a chamada do metodo getPacoteTracker passando somente 1 tracking code e nao uma lista. Caso seja necessario uma lista, voce podera usar o metodo getListaDePacotesTracker");
 					}
-					
+
 					boolean trackingCodeVazio = trackingCode == null || trackingCode.isEmpty();
 					if (trackingCodeVazio) {
 						throw new CorreiosCodigoRastreioInvalidoException("O Tracking code do objeto nao pode ser vazio");
 					}
-					
+
 					SoapCorreiosServicoRastreioApi serviceApi = new SoapCorreiosServicoRastreioApi(credentials);
-					
-					PacoteRastreadoDetalhes pacoteTrackerEncontrado = serviceApi.buscaPacoteRastreadoDetalhes(trackingCode, idioma, resultado, LISTA_DE_OBJETOS);
-					
-					return pacoteTrackerEncontrado;
+
+					return serviceApi.buscaDetalhesRastreio(trackingCode, idioma, resultado, LISTA_DE_OBJETOS);
 				}
-				
-				public List<PacoteRastreadoDetalhes> getListaDePacotesRastreados() {
+
+				public DetalhesRastreio getListaDePacotesRastreados() {
 					boolean listaDeTrackingCodesEstaVazia = trackingCodes == null || trackingCodes.isEmpty();
 					if (listaDeTrackingCodesEstaVazia) {
 						throw new CorreiosCodigoRastreioInvalidoException("A lista de Tracking Codes nao pode ser nula ou vazia");
 					}
-					
+
 					boolean existeSomenteUmTrackingCode = trackingCode != null && !trackingCode.isEmpty();
 					if (existeSomenteUmTrackingCode) {
 						throw new CorreiosCodigoRastreioInvalidoException("Voce deve fazer a chamada do metodo getListaDePacotesTracker passando uma lista de tracking codes. Caso seja necessario, utilize o metodo getPacoteTracker para somente 1 tracking code");
 					}
-					
+
 					SoapCorreiosServicoRastreioApi serviceApi = new SoapCorreiosServicoRastreioApi(credentials);
-					
-					List<PacoteRastreadoDetalhes> pacotesEncontrados = new ArrayList<PacoteRastreadoDetalhes>();
-					for (String trackingCode : trackingCodes) {
-						PacoteRastreadoDetalhes pacoteTrackerEncontrado = serviceApi.buscaPacoteRastreadoDetalhes(trackingCode, idioma, resultado, LISTA_DE_OBJETOS);
-						pacotesEncontrados.add(pacoteTrackerEncontrado);
-					}
-					
-					return pacotesEncontrados;
+
+					return serviceApi.buscaDetalhesRastreio(trackingCodes, idioma, resultado, LISTA_DE_OBJETOS);
 				}
 
 			}

--- a/src/main/java/br/com/correios/api/rastreio/service/CorreiosRastreioApi.java
+++ b/src/main/java/br/com/correios/api/rastreio/service/CorreiosRastreioApi.java
@@ -8,6 +8,8 @@ import static br.com.correios.api.rastreio.model.CorreiosTipoIdentificador.LISTA
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import br.com.correios.api.exception.CorreiosCodigoRastreioInvalidoException;
 import br.com.correios.api.rastreio.model.CorreiosEscopoResultado;
 import br.com.correios.api.rastreio.model.CorreiosIdioma;
@@ -39,7 +41,7 @@ public class CorreiosRastreioApi {
 		return new CorreiosRastreioComIdioma();
 	}
 
-	public CorreiosRastreioComIdioma buscaPacoteTrackerPelaListaDeTrackings(List<String> trackingCodes) {
+	public CorreiosRastreioComIdioma buscaPacotesRastreadosPelaListaDeTrackings(List<String> trackingCodes) {
 		this.trackingCodes = trackingCodes;
 		return new CorreiosRastreioComIdioma();
 	}
@@ -82,36 +84,14 @@ public class CorreiosRastreioApi {
 
 			public class CorreiosRastreioTracker {
 
-				public DetalhesRastreio getPacoteRastreado() {
-					boolean usuarioEnviouListaDeTrackingCodes = trackingCodes != null && !trackingCodes.isEmpty();
-					if (usuarioEnviouListaDeTrackingCodes) {
-						throw new CorreiosCodigoRastreioInvalidoException("Voce deve fazer a chamada do metodo getPacoteTracker passando somente 1 tracking code e nao uma lista. Caso seja necessario uma lista, voce podera usar o metodo getListaDePacotesTracker");
+				public DetalhesRastreio getDetalhesRastreio() {
+					if (trackingCodes != null && !trackingCodes.isEmpty()) {
+						return new SoapCorreiosServicoRastreioApi(credentials).buscaDetalhesRastreio(trackingCodes, idioma, resultado, LISTA_DE_OBJETOS);
+					} else if (StringUtils.isNotEmpty(trackingCode)) {
+						return new SoapCorreiosServicoRastreioApi(credentials).buscaDetalhesRastreio(trackingCode, idioma, resultado, LISTA_DE_OBJETOS);
+					} else {
+						throw new CorreiosCodigoRastreioInvalidoException("É necessário buscar os detalhes por pelo menos um código de rastreio");
 					}
-
-					boolean trackingCodeVazio = trackingCode == null || trackingCode.isEmpty();
-					if (trackingCodeVazio) {
-						throw new CorreiosCodigoRastreioInvalidoException("O Tracking code do objeto nao pode ser vazio");
-					}
-
-					SoapCorreiosServicoRastreioApi serviceApi = new SoapCorreiosServicoRastreioApi(credentials);
-
-					return serviceApi.buscaDetalhesRastreio(trackingCode, idioma, resultado, LISTA_DE_OBJETOS);
-				}
-
-				public DetalhesRastreio getListaDePacotesRastreados() {
-					boolean listaDeTrackingCodesEstaVazia = trackingCodes == null || trackingCodes.isEmpty();
-					if (listaDeTrackingCodesEstaVazia) {
-						throw new CorreiosCodigoRastreioInvalidoException("A lista de Tracking Codes nao pode ser nula ou vazia");
-					}
-
-					boolean existeSomenteUmTrackingCode = trackingCode != null && !trackingCode.isEmpty();
-					if (existeSomenteUmTrackingCode) {
-						throw new CorreiosCodigoRastreioInvalidoException("Voce deve fazer a chamada do metodo getListaDePacotesTracker passando uma lista de tracking codes. Caso seja necessario, utilize o metodo getPacoteTracker para somente 1 tracking code");
-					}
-
-					SoapCorreiosServicoRastreioApi serviceApi = new SoapCorreiosServicoRastreioApi(credentials);
-
-					return serviceApi.buscaDetalhesRastreio(trackingCodes, idioma, resultado, LISTA_DE_OBJETOS);
 				}
 
 			}

--- a/src/main/java/br/com/correios/api/rastreio/service/CorreiosServicoRastreioApi.java
+++ b/src/main/java/br/com/correios/api/rastreio/service/CorreiosServicoRastreioApi.java
@@ -1,11 +1,15 @@
 package br.com.correios.api.rastreio.service;
 
+import java.util.List;
+
 import br.com.correios.api.rastreio.model.CorreiosEscopoResultado;
 import br.com.correios.api.rastreio.model.CorreiosIdioma;
 import br.com.correios.api.rastreio.model.CorreiosTipoIdentificador;
+import br.com.correios.api.rastreio.model.DetalhesRastreio;
 
 public interface CorreiosServicoRastreioApi {
 
-	PacoteRastreadoDetalhes buscaPacoteRastreadoDetalhes(String codigoDeRastreio, CorreiosIdioma idioma, CorreiosEscopoResultado resultado, CorreiosTipoIdentificador tipoIdentificador);
-	
+	DetalhesRastreio buscaDetalhesRastreio(String codigoDeRastreio, CorreiosIdioma idioma, CorreiosEscopoResultado resultado, CorreiosTipoIdentificador tipoIdentificador);
+
+	DetalhesRastreio buscaDetalhesRastreio(List<String> codigosDeRastreio, CorreiosIdioma idioma, CorreiosEscopoResultado resultado, CorreiosTipoIdentificador tipoIdentificador);
 }

--- a/src/main/java/br/com/correios/api/rastreio/service/SoapCorreiosServicoRastreioApi.java
+++ b/src/main/java/br/com/correios/api/rastreio/service/SoapCorreiosServicoRastreioApi.java
@@ -1,6 +1,8 @@
 package br.com.correios.api.rastreio.service;
 
-import static br.com.correios.api.rastreio.model.CorreiosTipoIdentificador.LISTA_DE_OBJETOS;
+import static java.util.Arrays.asList;
+
+import java.util.List;
 
 import br.com.correios.api.converter.EventosDosCorreiosToPacoteRastreadoDetalhesConverter;
 import br.com.correios.api.exception.CorreiosEventosConverterException;
@@ -8,10 +10,13 @@ import br.com.correios.api.exception.CorreiosServicoSoapException;
 import br.com.correios.api.rastreio.model.CorreiosEscopoResultado;
 import br.com.correios.api.rastreio.model.CorreiosIdioma;
 import br.com.correios.api.rastreio.model.CorreiosTipoIdentificador;
+import br.com.correios.api.rastreio.model.DetalhesRastreio;
 import br.com.correios.credentials.CorreiosCredenciais;
 import br.com.correios.webservice.rastreio.EventosDosCorreios;
 import br.com.correios.webservice.rastreio.Rastro;
 import br.com.correios.webservice.rastreio.Service;
+
+
 
 /**
  * @author Alexandre Gama
@@ -28,16 +33,26 @@ class SoapCorreiosServicoRastreioApi implements CorreiosServicoRastreioApi {
 	}
 
 	@Override
-	public PacoteRastreadoDetalhes buscaPacoteRastreadoDetalhes(String codigoDeRastreio, CorreiosIdioma idioma, CorreiosEscopoResultado resultado, CorreiosTipoIdentificador tipoIdentificador) {
+	public DetalhesRastreio buscaDetalhesRastreio(String codigoDeRastreio, CorreiosIdioma idioma, CorreiosEscopoResultado resultado, CorreiosTipoIdentificador tipoIdentificador) {
+		return buscaDetalhes(idioma, resultado, tipoIdentificador, asList(codigoDeRastreio));
+	}
+
+
+	@Override
+	public DetalhesRastreio buscaDetalhesRastreio(List<String> codigosDeRastreio, CorreiosIdioma idioma, CorreiosEscopoResultado resultado, CorreiosTipoIdentificador tipoIdentificador) {
+		return buscaDetalhes(idioma, resultado, tipoIdentificador, codigosDeRastreio);
+	}
+
+	private DetalhesRastreio buscaDetalhes(CorreiosIdioma idioma, CorreiosEscopoResultado resultado, CorreiosTipoIdentificador tipoIdentificador, List<String> codigosDeRastreio) {
 		Service servicoApi = new Rastro().getServicePort();
 
 		EventosDosCorreios eventos = null;
 		try {
-			eventos = servicoApi.buscaEventos(credenciais.getUsuario(), credenciais.getSenha(),
-					LISTA_DE_OBJETOS.getCodigoInternoDosCorreios(),
+			eventos = servicoApi.buscaEventosLista(credenciais.getUsuario(), credenciais.getSenha(),
+					tipoIdentificador.getCodigoInternoDosCorreios(),
 					resultado.getCodigoInternoDosCorreios(),
 					idioma.getCodigoInternoDosCorreio(),
-					codigoDeRastreio);
+					codigosDeRastreio);
 		} catch (Exception e) {
 			throw new CorreiosServicoSoapException("Ocorreu um erro ao fazer a chamada SOAP para os correios. Verifique se voce passou corretamente os dados desejados", e);
 		}

--- a/src/test/java/br/com/correios/api/converter/EventosDosCorreiosToPacoteRastreadoDetalhesConverterTest.java
+++ b/src/test/java/br/com/correios/api/converter/EventosDosCorreiosToPacoteRastreadoDetalhesConverterTest.java
@@ -7,9 +7,10 @@ import java.util.Calendar;
 
 import org.junit.Test;
 
+import br.com.correios.api.rastreio.model.DetalhesRastreio;
 import br.com.correios.api.rastreio.model.Evento;
 import br.com.correios.api.rastreio.model.LocalDoPacote;
-import br.com.correios.api.rastreio.service.PacoteRastreadoDetalhes;
+import br.com.correios.api.rastreio.model.ObjetoRastreio;
 import br.com.correios.webservice.rastreio.Destinos;
 import br.com.correios.webservice.rastreio.Eventos;
 import br.com.correios.webservice.rastreio.EventosDosCorreios;
@@ -22,35 +23,35 @@ public class EventosDosCorreiosToPacoteRastreadoDetalhesConverterTest {
 		EventosDosCorreios eventosDosCorreios = new EventosDosCorreios();
 		eventosDosCorreios.setQtd("12");
 		eventosDosCorreios.setVersao("1");
-		
+
 		EventosDosCorreiosToPacoteRastreadoDetalhesConverter converter = new EventosDosCorreiosToPacoteRastreadoDetalhesConverter();
-		PacoteRastreadoDetalhes pacoteRastreado = converter.convert(eventosDosCorreios);
-		
+		DetalhesRastreio pacoteRastreado = converter.convert(eventosDosCorreios);
+
 		assertThat(pacoteRastreado.getQuantidade()).isEqualTo(12);
 		assertThat(pacoteRastreado.getVersao()).isEqualTo("1");
 	}
-	
+
 	@Test
 	public void deveriaConverterAsInformacoesDeObjetoDeEventosDosCorreiosParaUmObjetoPacoteRastreadoDetalhes() throws Exception {
 		EventosDosCorreios eventosDosCorreios = new EventosDosCorreios();
 		eventosDosCorreios.setQtd("12");
 		eventosDosCorreios.setVersao("1");
-		
+
 		Objeto primeiroObjeto = new Objeto();
 		primeiroObjeto.setCategoria("E-SEDEX");
 		primeiroObjeto.setNome("Encomenda E-SEDEX");
 		primeiroObjeto.setNumero("123456789");
 		primeiroObjeto.setSigla("DU");
-		
+
 		eventosDosCorreios.getObjeto().add(primeiroObjeto);
-		
+
 		EventosDosCorreiosToPacoteRastreadoDetalhesConverter converter = new EventosDosCorreiosToPacoteRastreadoDetalhesConverter();
-		PacoteRastreadoDetalhes pacoteRastreado = converter.convert(eventosDosCorreios);
-		
-		assertThat(pacoteRastreado.getCategoria()).isEqualTo("E-SEDEX");
-		assertThat(pacoteRastreado.getNome()).isEqualTo("Encomenda E-SEDEX");
-		assertThat(pacoteRastreado.getNumero()).isEqualTo("123456789");
-		assertThat(pacoteRastreado.getSigla()).isEqualTo("DU");
+		ObjetoRastreio objetoRastreio = converter.convert(eventosDosCorreios).getObjetosRastreio().get(0);
+
+		assertThat(objetoRastreio.getCategoria()).isEqualTo("E-SEDEX");
+		assertThat(objetoRastreio.getNome()).isEqualTo("Encomenda E-SEDEX");
+		assertThat(objetoRastreio.getNumero()).isEqualTo("123456789");
+		assertThat(objetoRastreio.getSigla()).isEqualTo("DU");
 	}
 
 	@Test
@@ -58,13 +59,13 @@ public class EventosDosCorreiosToPacoteRastreadoDetalhesConverterTest {
 		EventosDosCorreios eventosDosCorreios = new EventosDosCorreios();
 		eventosDosCorreios.setQtd("12");
 		eventosDosCorreios.setVersao("1");
-		
+
 		Objeto objetoRastreado = new Objeto();
 		objetoRastreado.setCategoria("E-SEDEX");
 		objetoRastreado.setNome("Encomenda E-SEDEX");
 		objetoRastreado.setNumero("123456789");
 		objetoRastreado.setSigla("DU");
-		
+
 		Eventos eventos = new Eventos();
 		eventos.setTipo("BDE");
 		eventos.setStatus("01");
@@ -74,59 +75,60 @@ public class EventosDosCorreiosToPacoteRastreadoDetalhesConverterTest {
 		eventos.setData(dataNoFormatoDosCorreios);
 		objetoRastreado.getEvento().add(eventos);
 		eventosDosCorreios.getObjeto().add(objetoRastreado);
-		
+
 		EventosDosCorreiosToPacoteRastreadoDetalhesConverter converter = new EventosDosCorreiosToPacoteRastreadoDetalhesConverter();
-		PacoteRastreadoDetalhes pacoteRastreado = converter.convert(eventosDosCorreios);
-		
-		Evento eventoConvertido = pacoteRastreado.getPrimeiroEvento().get();
-		
+		ObjetoRastreio objetoRastreio = converter.convert(eventosDosCorreios).getObjetosRastreio().get(0);
+
+		Evento eventoConvertido = objetoRastreio.getPrimeiroEvento().get();
+
 		Calendar dataEsperada = Calendar.getInstance();
 		dataEsperada.setTime(new SimpleDateFormat("dd/MM/yyyy").parse(dataNoFormatoDosCorreios));
-		
-		assertThat(pacoteRastreado.getQuantidadeDeEventosOcorridos()).isEqualTo(1);
+
+		assertThat(objetoRastreio.getQuantidadeDeEventosOcorridos()).isEqualTo(1);
 		assertThat(eventoConvertido.getTipo()).isEqualTo("BDE");
 		assertThat(eventoConvertido.getStatus()).isEqualTo("01");
 		assertThat(eventoConvertido.getHora()).isEqualTo("02:30");
 		assertThat(eventoConvertido.getDescricao()).isEqualTo("Objeto entregue ao destinatário");
 		assertThat(eventoConvertido.getData()).isEqualTo(dataEsperada);
 	}
-	
+
 	@Test
 	public void deveriaConverterOsDadosDosEventosEmUmObjetoContendoODestinoDosEventos() throws Exception {
 		EventosDosCorreios eventosDosCorreios = new EventosDosCorreios();
 		eventosDosCorreios.setQtd("12");
 		eventosDosCorreios.setVersao("1");
-		
+
 		Objeto objetoRastreado = new Objeto();
 		objetoRastreado.setCategoria("E-SEDEX");
 		objetoRastreado.setNome("Encomenda E-SEDEX");
 		objetoRastreado.setNumero("123456789");
 		objetoRastreado.setSigla("DU");
-		
+
 		Eventos eventos = new Eventos();
 		eventos.setTipo("BDE");
 		eventos.setStatus("01");
 		eventos.setHora("02:30");
 		eventos.setDescricao("Objeto entregue ao destinatário");
 		eventos.setData("15/06/2016");
-		
+
 		Destinos destinoDosCorreios = new Destinos();
 		destinoDosCorreios.setLocal("Rua Beira Rio");
 		destinoDosCorreios.setCodigo("123456");
 		destinoDosCorreios.setCidade("Sao Paulo");
 		destinoDosCorreios.setBairro("Vila Olimpia");
 		destinoDosCorreios.setUf("SP");
-		
+
 		objetoRastreado.getEvento().add(eventos);
 		eventosDosCorreios.getObjeto().add(objetoRastreado);
 		eventos.getDestino().add(destinoDosCorreios);
-		
+
 		EventosDosCorreiosToPacoteRastreadoDetalhesConverter converter = new EventosDosCorreiosToPacoteRastreadoDetalhesConverter();
-		PacoteRastreadoDetalhes pacoteRastreado = converter.convert(eventosDosCorreios);
-		
-		LocalDoPacote localDoDestino = pacoteRastreado.getPrimeiroEvento().get().getPrimeiroDestino().get().getLocal();
-		
-		assertThat(pacoteRastreado.getQuantidadeDeEventosOcorridos()).isEqualTo(1);
+		DetalhesRastreio pacoteRastreado = converter.convert(eventosDosCorreios);
+
+		ObjetoRastreio primeiroObjetoRastreio = pacoteRastreado.getObjetosRastreio().get(0);
+		LocalDoPacote localDoDestino = primeiroObjetoRastreio.getPrimeiroEvento().get().getPrimeiroDestino().get().getLocal();
+
+		assertThat(primeiroObjetoRastreio.getQuantidadeDeEventosOcorridos()).isEqualTo(1);
 		assertThat(localDoDestino.getNome()).isEqualTo("Rua Beira Rio");
 		assertThat(localDoDestino.getCodigo()).isEqualTo("123456");
 		assertThat(localDoDestino.getBairro()).isEqualTo("Vila Olimpia");
@@ -138,34 +140,34 @@ public class EventosDosCorreiosToPacoteRastreadoDetalhesConverterTest {
 		EventosDosCorreios eventosDosCorreios = new EventosDosCorreios();
 		eventosDosCorreios.setQtd("12");
 		eventosDosCorreios.setVersao("1");
-		
+
 		Objeto objetoRastreado = new Objeto();
 		objetoRastreado.setCategoria("E-SEDEX");
 		objetoRastreado.setNome("Encomenda E-SEDEX");
 		objetoRastreado.setNumero("123456789");
 		objetoRastreado.setSigla("DU");
-		
+
 		Eventos primeiroEvento = new Eventos();
 		primeiroEvento.setTipo("BDE");
 		primeiroEvento.setStatus("01");
 		primeiroEvento.setHora("02:30");
 		primeiroEvento.setDescricao("Objeto entregue ao destinatário");
 		primeiroEvento.setData("15/06/2016");
-		
+
 		Eventos segundoEvento = new Eventos();
 		segundoEvento.setTipo("BDE");
 		segundoEvento.setStatus("01");
 		segundoEvento.setHora("02:30");
 		segundoEvento.setDescricao("Objeto entregue ao destinatário");
 		segundoEvento.setData("15/06/2016");
-		
+
 		objetoRastreado.getEvento().add(primeiroEvento);
 		objetoRastreado.getEvento().add(segundoEvento);
 		eventosDosCorreios.getObjeto().add(objetoRastreado);
-		
+
 		EventosDosCorreiosToPacoteRastreadoDetalhesConverter converter = new EventosDosCorreiosToPacoteRastreadoDetalhesConverter();
-		PacoteRastreadoDetalhes pacoteRastreado = converter.convert(eventosDosCorreios);
-		
-		assertThat(pacoteRastreado.getQuantidadeDeEventosOcorridos()).isEqualTo(2);
+		DetalhesRastreio pacoteRastreado = converter.convert(eventosDosCorreios);
+
+		assertThat(pacoteRastreado.getObjetosRastreio().get(0).getQuantidadeDeEventosOcorridos()).isEqualTo(2);
 	}
 }

--- a/src/test/java/br/com/correios/api/rastreio/service/CorreiosRastreioApiTest.java
+++ b/src/test/java/br/com/correios/api/rastreio/service/CorreiosRastreioApiTest.java
@@ -1,0 +1,35 @@
+package br.com.correios.api.rastreio.service;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import br.com.correios.api.exception.CorreiosCodigoRastreioInvalidoException;
+import br.com.correios.credentials.CorreiosCredenciais;
+
+public class CorreiosRastreioApiTest {
+
+	private CorreiosRastreioApi correiosApi;
+
+	@Before
+	public void setup() {
+		CorreiosCredenciais credentials = new CorreiosCredenciais("12345", "12345");
+		correiosApi = new CorreiosRastreioApi(credentials);
+	}
+
+	@Test(expected=CorreiosCodigoRastreioInvalidoException.class)
+	public void deveriaLancarExcecaoQuandoNaoPassarCodigoDeRastreio() {
+		correiosApi.buscaPacoteRastreadoUsandoOCodigo("").comRetornoEmPortugues().comTodosOsEventos().getDetalhesRastreio();
+	}
+
+	@Test(expected=CorreiosCodigoRastreioInvalidoException.class)
+	public void deveriaLancarExcecaoQuandoNaoPassarCodigosDeRastreio() {
+		correiosApi.buscaPacotesRastreadosPelaListaDeTrackings(null).comRetornoEmPortugues().comTodosOsEventos().getDetalhesRastreio();
+	}
+
+	@Test(expected=CorreiosCodigoRastreioInvalidoException.class)
+	public void deveriaLancarExcecaoQuandoPassarListaDeCodigosDeRastreioVazia() {
+		correiosApi.buscaPacotesRastreadosPelaListaDeTrackings(Collections.emptyList()).comRetornoEmPortugues().comTodosOsEventos().getDetalhesRastreio();
+	}
+}

--- a/src/test/java/br/com/correios/api/rastreio/service/CorreiosRastreioClientApiTest.java
+++ b/src/test/java/br/com/correios/api/rastreio/service/CorreiosRastreioClientApiTest.java
@@ -3,6 +3,7 @@ package br.com.correios.api.rastreio.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import br.com.correios.api.rastreio.model.DetalhesRastreio;
@@ -10,39 +11,35 @@ import br.com.correios.credentials.CorreiosCredenciais;
 
 public class CorreiosRastreioClientApiTest {
 
+	private CorreiosRastreioApi correiosApi;
+
+	@Before
+	public void setup() {
+		CorreiosCredenciais credentials = new CorreiosCredenciais("12345", "12345");
+		correiosApi = new CorreiosRastreioApi(credentials);
+	}
+
 	@Test
 	public void deveriaRetornarOsEventosAPartirDeUmTrackingCode() {
-		CorreiosCredenciais credentials = new CorreiosCredenciais("12345", "12345");
-
-		CorreiosRastreioApi correiosApi = new CorreiosRastreioApi(credentials);
-
-		DetalhesRastreio pacoteTracker = correiosApi.buscaPacoteRastreadoUsandoOCodigo("PN601598269BR").comRetornoEmPortugues().comTodosOsEventos().getPacoteRastreado();
+		DetalhesRastreio pacoteTracker = correiosApi.buscaPacoteRastreadoUsandoOCodigo("PN601598269BR").comRetornoEmPortugues().comTodosOsEventos().getDetalhesRastreio();
 
 		System.out.println(pacoteTracker);
 	}
 
 	@Test
 	public void deveriaRetornarSomenteOUltimoEventoAPartirDeUmTrackingCode() {
-		CorreiosCredenciais credentials = new CorreiosCredenciais("12345", "12345");
-
-		CorreiosRastreioApi correiosApi = new CorreiosRastreioApi(credentials);
-
-		DetalhesRastreio detalhesRastreio = correiosApi.buscaPacoteRastreadoUsandoOCodigo("DU500853237BR").comRetornoEmPortugues().somenteUltimoEvento().getPacoteRastreado();
+		DetalhesRastreio detalhesRastreio = correiosApi.buscaPacoteRastreadoUsandoOCodigo("DU500853237BR").comRetornoEmPortugues().somenteUltimoEvento().getDetalhesRastreio();
 
 		System.out.println(detalhesRastreio);
 	}
 
 	@Test
 	public void deveriaRetornarOsEventosAPartirDeUmaListaDeTrackingCodes() {
-		CorreiosCredenciais credentials = new CorreiosCredenciais("12345", "12345");
-
-		CorreiosRastreioApi correiosApi = new CorreiosRastreioApi(credentials);
-
 		List<String> trackingCodes = new ArrayList<>();
 		trackingCodes.add("DU500853237BR");
 		trackingCodes.add("DU496842125BR");
 
-		DetalhesRastreio detalhesRastreio = correiosApi.buscaPacoteTrackerPelaListaDeTrackings(trackingCodes).comRetornoEmPortugues().comTodosOsEventos().getListaDePacotesRastreados();
+		DetalhesRastreio detalhesRastreio = correiosApi.buscaPacotesRastreadosPelaListaDeTrackings(trackingCodes).comRetornoEmPortugues().comTodosOsEventos().getDetalhesRastreio();
 
 		System.out.println(detalhesRastreio);
 	}

--- a/src/test/java/br/com/correios/api/rastreio/service/CorreiosRastreioClientApiTest.java
+++ b/src/test/java/br/com/correios/api/rastreio/service/CorreiosRastreioClientApiTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import br.com.correios.api.rastreio.model.DetalhesRastreio;
 import br.com.correios.credentials.CorreiosCredenciais;
 
 public class CorreiosRastreioClientApiTest {
@@ -15,7 +16,7 @@ public class CorreiosRastreioClientApiTest {
 
 		CorreiosRastreioApi correiosApi = new CorreiosRastreioApi(credentials);
 
-		PacoteRastreadoDetalhes pacoteTracker = correiosApi.buscaPacoteRastreadoUsandoOCodigo("PN601598269BR").comRetornoEmPortugues().comTodosOsEventos().getPacoteRastreado();
+		DetalhesRastreio pacoteTracker = correiosApi.buscaPacoteRastreadoUsandoOCodigo("PN601598269BR").comRetornoEmPortugues().comTodosOsEventos().getPacoteRastreado();
 
 		System.out.println(pacoteTracker);
 	}
@@ -26,9 +27,9 @@ public class CorreiosRastreioClientApiTest {
 
 		CorreiosRastreioApi correiosApi = new CorreiosRastreioApi(credentials);
 
-		PacoteRastreadoDetalhes pacoteTracker = correiosApi.buscaPacoteRastreadoUsandoOCodigo("DU500853237BR").comRetornoEmPortugues().somenteUltimoEvento().getPacoteRastreado();
+		DetalhesRastreio detalhesRastreio = correiosApi.buscaPacoteRastreadoUsandoOCodigo("DU500853237BR").comRetornoEmPortugues().somenteUltimoEvento().getPacoteRastreado();
 
-		System.out.println(pacoteTracker);
+		System.out.println(detalhesRastreio);
 	}
 
 	@Test
@@ -41,9 +42,9 @@ public class CorreiosRastreioClientApiTest {
 		trackingCodes.add("DU500853237BR");
 		trackingCodes.add("DU496842125BR");
 
-		List<PacoteRastreadoDetalhes> listaDeEventos = correiosApi.buscaPacoteTrackerPelaListaDeTrackings(trackingCodes).comRetornoEmPortugues().comTodosOsEventos().getListaDePacotesRastreados();
+		DetalhesRastreio detalhesRastreio = correiosApi.buscaPacoteTrackerPelaListaDeTrackings(trackingCodes).comRetornoEmPortugues().comTodosOsEventos().getListaDePacotesRastreados();
 
-		System.out.println(listaDeEventos);
+		System.out.println(detalhesRastreio);
 	}
 
 }


### PR DESCRIPTION
referente a issue #41 

# Changelog

- [ ] Quando a busca for feita por mais de um código de rastreio, a API vai usar o método do Web Service que recebe uma lista de códigos de rastreio.
- [ ] Tanto para buscar um pacote, quanto para buscar vários pacotes, a API vai retornar um objeto que possui uma lista com os pacotes rastreados que foram pedidos